### PR TITLE
Added SVG symbol for external links

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -152,11 +152,11 @@ a {
     text-decoration: none;
 }
 
-a[href^="http"] {
-    background-position: center right;
-    background-repeat: no-repeat;
-    background-image: linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22%3E %3Cpath fill=%22%23fff%22 stroke=%22%2336c%22 d=%22M1.5 4.518h5.982V10.5H1.5z%22/%3E %3Cpath fill=%22%2336c%22 d=%22M5.765 1H11v5.39L9.427 7.937l-1.31-1.31L5.393 9.35l-2.69-2.688 2.81-2.808L4.2 2.544z%22/%3E %3Cpath fill=%22%23fff%22 d=%22M9.995 2.004l.022 4.885L8.2 5.07 5.32 7.95 4.09 6.723l2.882-2.88-1.85-1.852z%22/%3E %3C/svg%3E");
-    padding-right: 13px;
+a[href^="http"]::after {
+    padding: 0 0.1rem;
+    font-size: 75%;
+    content: "🔗";
+    line-height: 0;
 }
 
 a:hover {

--- a/assets/style.css
+++ b/assets/style.css
@@ -152,6 +152,13 @@ a {
     text-decoration: none;
 }
 
+a[href^="http"] {
+    background-position: center right;
+    background-repeat: no-repeat;
+    background-image: linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22%3E %3Cpath fill=%22%23fff%22 stroke=%22%2336c%22 d=%22M1.5 4.518h5.982V10.5H1.5z%22/%3E %3Cpath fill=%22%2336c%22 d=%22M5.765 1H11v5.39L9.427 7.937l-1.31-1.31L5.393 9.35l-2.69-2.688 2.81-2.808L4.2 2.544z%22/%3E %3Cpath fill=%22%23fff%22 d=%22M9.995 2.004l.022 4.885L8.2 5.07 5.32 7.95 4.09 6.723l2.882-2.88-1.85-1.852z%22/%3E %3C/svg%3E");
+    padding-right: 13px;
+}
+
 a:hover {
     text-decoration: underline;
 }


### PR DESCRIPTION
Adresses issue #62 to make a visible difference between internal and external links. The style applied to external links is shamelessly copied from Wikipedia/Mediawiki.

I believe the code snippet taken from Mediawiki is too short and generic to be copyrightable. However, to be fair, the original code is released under a GPL v2 licence and we may add a notice somewhere in the credits that this specific contribution is taken from Mediawiki.