### PR TITLE
UI: Reduced line-height for code blocks (pre tags)

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -145,6 +145,7 @@ code, pre {
 
 pre {
     overflow: auto;
+    line-height: 22px;
 }
 
 a {


### PR DESCRIPTION
CSS `line-height` is way too big for code blocks out of-the-box. So when you have some empty lines in a code block it becomes mostly unreadable. I feel like `22px` is a better default given the `18px` default font-size.

You can see this change running in production [here](https://wiki.n07070.xyz/wiki) :)