### PR TITLE
Do not underline external link marker on hover

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -167,6 +167,11 @@ a[href^="http"]::after {
     line-height: 0;
 }
 
+a[href^="http"]:hover::after {
+    display: inline-block;
+    text-decoration: none;
+}
+
 a:hover {
     text-decoration: underline;
 }


### PR DESCRIPTION
Complements #63 (aesthetics). Removes underline on the external link marker when the link is being hovered.

Note that the `display: inline-block;` is necessary as otherwise (as per the standards) the `::after` part with the marker is considered part of the element (`<a>`) itself, and therefore the more generic rule would not apply.