### PR TITLE
Build for both x86_64 and ARM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ rust:
 - beta
 - nightly
 
+arch:
+  - amd64
+  - arm64
+
 matrix:
   allow_failures:
   - rust: nightly
@@ -13,11 +17,12 @@ before_install:
   - sudo apt-get install -y musl-tools
 
 script:
-- rustup target add x86_64-unknown-linux-musl
-- cargo test --target=x86_64-unknown-linux-musl
-- cargo build --release --target=x86_64-unknown-linux-musl
-- strip -s target/x86_64-unknown-linux-musl/release/sausagewiki
-- XZ_OPT=-9 tar Jcf sausagewiki.tar.xz -C target/x86_64-unknown-linux-musl/release/ sausagewiki
+- TARGET=`[ $TRAVIS_CPU_ARCH == 'amd64' ] && echo x86_64 || echo aarch64`-unknown-linux-musl
+- rustup target add $TARGET
+- cargo test --target=$TARGET
+- cargo build --release --target=$TARGET
+- strip -s target/$TARGET/release/sausagewiki
+- XZ_OPT=-9 tar Jcf sausagewiki-$TRAVIS_CPU_ARCH.tar.xz -C target/$TARGET/release/ sausagewiki
 
 branches:
   except:


### PR DESCRIPTION
This might work, but I haven't tested it.

I know following the script, but with `aarch64-unknown-linux-musl` works. I've followed the documentation for [multiple architectures](https://docs.travis-ci.com/user/multi-cpu-architectures/) and [TRAVIS_CPU_ARCH](https://docs.travis-ci.com/user/environment-variables/), but I don't know if I can actually set an environment variable in a travis-script.

Also, a "regression" here, is that the artifact will change name (postfixed), which might break everything.

So... take from this what you want :)